### PR TITLE
Adjust API endpoint

### DIFF
--- a/lib/xeno-canto.js
+++ b/lib/xeno-canto.js
@@ -20,7 +20,7 @@ function XenoCanto(){
 /** Search for name of advanced options*/
 XenoCanto.prototype.search = function(query, success){
 	if (!!query) {
-		var url = 'http://www.xeno-canto.org/api/recordings.php?query=';
+		var url = 'http://www.xeno-canto.org/api/2/recordings?query=';
 
 		// Duck-typing args
 		if (typeof(query) === 'string') {


### PR DESCRIPTION
Updates the API endpoint for XenoCanto. The rest library used doesn't seem to follow redirects (or perhaps XenoCanto isn't setting a header in the 300's range properly) so this is needed in order for the module to continue to work.
